### PR TITLE
Add `VimEnter` to `relative_events`

### DIFF
--- a/lua/numbers/init.lua
+++ b/lua/numbers/init.lua
@@ -24,6 +24,7 @@ M.options = {
     'BufReadPost',
   },
   relative_events = {
+    'VimEnter',
     'InsertLeave',
     'WinEnter',
     'FocusGained',


### PR DESCRIPTION
When I enter Neovim, it always shows the absolute line numbers instead of the absolute and relative line numbers, even though I am in normal mode. This simple patch fixes that.