### PR TITLE
Fix a bug caused by usage of global value

### DIFF
--- a/lua/numbers/init.lua
+++ b/lua/numbers/init.lua
@@ -2,7 +2,7 @@ local function autocmd(events, command)
   vim.api.nvim_create_autocmd(events, {group='NumbersAutocmds', command=command})
 end
 
-M = {}
+local M = {}
 
 M.options = {
   excluded_filetypes = {


### PR DESCRIPTION
Actually this plugin is conflicted with another plugin `cuducos/yaml.nvim` that is also using a global 'M'